### PR TITLE
Add PHP 8.3 support and update package dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2 ]
+        php-version: [ 8.1, 8.2, 8.3 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2 ]
+        php-version: [ 8.1, 8.2, 8.3 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2 ]
+        php-version: [ 8.1, 8.2, 8.3 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/composer.json
+++ b/composer.json
@@ -30,15 +30,15 @@
     "require"           : {
         "php"         : "^8.1",
 
-        "jbzoo/utils" : "^7.0",
+        "jbzoo/utils" : "^7.1",
         "jbzoo/path"  : "^7.0",
         "jbzoo/less"  : "^7.0",
-        "jbzoo/data"  : "^7.0"
+        "jbzoo/data"  : "^7.1"
     },
 
     "require-dev"       : {
-        "jbzoo/toolbox-dev"  : "^7.0",
-        "symfony/filesystem" : ">=5.2.3"
+        "jbzoo/toolbox-dev"  : "^7.1",
+        "symfony/filesystem" : ">=6.4.0"
     },
 
     "autoload"          : {


### PR DESCRIPTION
The changes in this commit extend our project's compatibility by including support for PHP 8.3. In addition, dependencies including "jbzoo/utils", "jbzoo/data", and "jbzoo/toolbox-dev" have been updated to the latest minor versions. The version for "symfony/filesystem" in the development environment has also been raised, keeping our development tools up-to-date.