### PR TITLE
8.0.0 — PHP 8.3+ floor & lock-step major

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,15 @@ permissions:
   contents: read
 
 on:
+  schedule:
+    - cron: '0 4 * * *'   # daily 04:00 UTC canary keepalive
   pull_request:
     branches:
       - "*"
   push:
     branches:
       - 'master'
+  workflow_dispatch: {}
 
 env:
   COLUMNS: 120
@@ -34,12 +37,12 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -58,18 +61,19 @@ jobs:
         run: make test --no-print-directory
 
       - name: Uploading coverage to coveralls
-        if: ${{ matrix.coverage == 'xdebug' }}
+        if: '${{ matrix.coverage == ''xdebug'' }}'
         continue-on-error: true
         env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make report-coveralls --no-print-directory || true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: PHPUnit - ${{ matrix.php-version }} - ${{ matrix.coverage }}
           path: build/
+          overwrite: true
 
 
   linters:
@@ -77,10 +81,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -99,11 +103,12 @@ jobs:
         run: make codestyle --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: Linters - ${{ matrix.php-version }}
           path: build/
+          overwrite: true
 
 
   report:
@@ -111,10 +116,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -133,8 +138,9 @@ jobs:
         run: make report-all --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: Reports - ${{ matrix.php-version }}
           path: build/
+          overwrite: true

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ try {
 
 ## Requirements
 
-- PHP 8.2 or higher
+- PHP 8.3 or higher
 - JBZoo Utils package
 - JBZoo Path package
 - JBZoo Data package

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # JBZoo / Assets
 
-[![CI](https://github.com/JBZoo/Assets/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Assets/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Assets/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Assets?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Assets/coverage.svg)](https://shepherd.dev/github/JBZoo/Assets)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Assets/level.svg)](https://shepherd.dev/github/JBZoo/Assets)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/assets/badge)](https://www.codefactor.io/repository/github/jbzoo/assets/issues)
-[![Stable Version](https://poser.pugx.org/jbzoo/assets/version)](https://packagist.org/packages/jbzoo/assets/)    [![Total Downloads](https://poser.pugx.org/jbzoo/assets/downloads)](https://packagist.org/packages/jbzoo/assets/stats)    [![Dependents](https://poser.pugx.org/jbzoo/assets/dependents)](https://packagist.org/packages/jbzoo/assets/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/assets)](https://github.com/JBZoo/Assets/blob/master/LICENSE)
+[![CI](https://github.com/JBZoo/Assets/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Assets/actions/workflows/main.yml?query=branch%3Amaster)
+[![Coverage Status](https://coveralls.io/repos/github/JBZoo/Assets/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Assets?branch=master)
+[![Psalm Coverage](https://shepherd.dev/github/JBZoo/Assets/coverage.svg)](https://shepherd.dev/github/JBZoo/Assets)
+[![Psalm Level](https://shepherd.dev/github/JBZoo/Assets/level.svg)](https://shepherd.dev/github/JBZoo/Assets)
+[![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/assets/badge)](https://www.codefactor.io/repository/github/jbzoo/assets/issues)
+
+[![Stable Version](https://poser.pugx.org/jbzoo/assets/version)](https://packagist.org/packages/jbzoo/assets/)
+[![Total Downloads](https://poser.pugx.org/jbzoo/assets/downloads)](https://packagist.org/packages/jbzoo/assets/stats)
+[![Dependents](https://poser.pugx.org/jbzoo/assets/dependents)](https://packagist.org/packages/jbzoo/assets/dependents?order_by=downloads)
+[![GitHub License](https://img.shields.io/github/license/jbzoo/assets)](https://github.com/JBZoo/Assets/blob/master/LICENSE)
 
 A PHP library for managing asset files (JavaScript, CSS, LESS, JSX) with dependency resolution, compression, and merging capabilities. The library provides automatic type detection, dependency management, and a flexible build system for modern web applications.
 

--- a/composer.json
+++ b/composer.json
@@ -28,17 +28,17 @@
     "prefer-stable"     : true,
 
     "require"           : {
-        "php"         : "^8.2",
+        "php"         : "^8.3",
 
-        "jbzoo/utils" : "^7.3",
-        "jbzoo/path"  : "^7.0.1",
-        "jbzoo/less"  : "^7.0.1",
-        "jbzoo/data"  : "^7.2"
+        "jbzoo/utils" : "^8.0",
+        "jbzoo/path"  : "^8.0",
+        "jbzoo/less"  : "^8.0",
+        "jbzoo/data"  : "^8.0"
     },
 
     "require-dev"       : {
-        "jbzoo/toolbox-dev"  : "^7.2",
-        "symfony/filesystem" : ">=7.3.2"
+        "jbzoo/toolbox-dev"  : "^8.0",
+        "symfony/filesystem" : ">=7.3.4"
     },
 
     "autoload"          : {
@@ -56,7 +56,7 @@
 
     "extra"             : {
         "branch-alias" : {
-            "dev-master" : "7.x-dev"
+            "dev-master" : "8.x-dev"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,25 +10,14 @@
     @copyright  Copyright (C) JBZoo.com, All rights reserved.
     @see        https://github.com/JBZoo/Assets
 -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="tests/autoload.php"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         convertDeprecationsToExceptions="true"
-         executionOrder="random"
+<phpunit bootstrap="tests/autoload.php"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
          stopOnIncomplete="false"
          stopOnSkipped="false"
-         stopOnRisky="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
->
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
+         stopOnRisky="false">
+    <coverage>
         <report>
             <clover outputFile="build/coverage_xml/main.xml"/>
             <php outputFile="build/coverage_cov/main.cov"/>
@@ -45,4 +34,10 @@
     <logging>
         <junit outputFile="build/coverage_junit/main.xml"/>
     </logging>
+
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/Asset/AbstractAsset.php
+++ b/src/Asset/AbstractAsset.php
@@ -23,15 +23,15 @@ use function JBZoo\Data\data;
 
 abstract class AbstractAsset
 {
-    public const TYPE_JS_FILE    = 'js';
-    public const TYPE_JS_CODE    = 'js_code';
-    public const TYPE_JSX_FILE   = 'jsx';
-    public const TYPE_JSX_CODE   = 'jsx_code';
-    public const TYPE_CSS_FILE   = 'css';
-    public const TYPE_CSS_CODE   = 'css_code';
-    public const TYPE_LESS_FILE  = 'less';
-    public const TYPE_CALLBACK   = 'callback';
-    public const TYPE_COLLECTION = 'collection';
+    public const string TYPE_JS_FILE    = 'js';
+    public const string TYPE_JS_CODE    = 'js_code';
+    public const string TYPE_JSX_FILE   = 'jsx';
+    public const string TYPE_JSX_CODE   = 'jsx_code';
+    public const string TYPE_CSS_FILE   = 'css';
+    public const string TYPE_CSS_CODE   = 'css_code';
+    public const string TYPE_LESS_FILE  = 'less';
+    public const string TYPE_CALLBACK   = 'callback';
+    public const string TYPE_COLLECTION = 'collection';
 
     protected string                $alias;
     protected array|\Closure|string $source;

--- a/src/Asset/AbstractFile.php
+++ b/src/Asset/AbstractFile.php
@@ -21,7 +21,7 @@ use JBZoo\Utils\Url;
 
 abstract class AbstractFile extends AbstractAsset
 {
-    public const TYPE = 'abstract';
+    public const string TYPE = 'abstract';
 
     public function load(): array
     {

--- a/src/Asset/CssFile.php
+++ b/src/Asset/CssFile.php
@@ -18,5 +18,5 @@ namespace JBZoo\Assets\Asset;
 
 final class CssFile extends AbstractFile
 {
-    public const TYPE = AbstractAsset::TYPE_CSS_FILE;
+    public const string TYPE = AbstractAsset::TYPE_CSS_FILE;
 }

--- a/src/Asset/JsFile.php
+++ b/src/Asset/JsFile.php
@@ -18,5 +18,5 @@ namespace JBZoo\Assets\Asset;
 
 final class JsFile extends AbstractFile
 {
-    public const TYPE = AbstractAsset::TYPE_JS_FILE;
+    public const string TYPE = AbstractAsset::TYPE_JS_FILE;
 }

--- a/src/Asset/JsxFile.php
+++ b/src/Asset/JsxFile.php
@@ -18,5 +18,5 @@ namespace JBZoo\Assets\Asset;
 
 final class JsxFile extends AbstractFile
 {
-    public const TYPE = AbstractAsset::TYPE_JSX_FILE;
+    public const string TYPE = AbstractAsset::TYPE_JSX_FILE;
 }

--- a/src/Asset/LessFile.php
+++ b/src/Asset/LessFile.php
@@ -20,7 +20,7 @@ use JBZoo\Less\Less;
 
 final class LessFile extends AbstractFile
 {
-    public const TYPE = AbstractAsset::TYPE_LESS_FILE;
+    public const string TYPE = AbstractAsset::TYPE_LESS_FILE;
 
     public function load(): array
     {


### PR DESCRIPTION
Coordinated ecosystem-wide **8.0** major (packaging-driven).

- Minimum PHP raised to **8.3** (CI: 8.3 / 8.4 / 8.5).
- All inter-package `jbzoo/*` deps → `^8.0`.

### Changed (BC)
- Public constants `AbstractAsset::TYPE_*` and `AbstractFile::TYPE` (overridden by `Css`/`Js`/`Jsx`/`LessFile`) are now typed — external overriders must match the type.
